### PR TITLE
Feature/builder

### DIFF
--- a/.changeset/server-package-introduction.md
+++ b/.changeset/server-package-introduction.md
@@ -1,0 +1,12 @@
+---
+"@mcpkit/server": patch
+---
+
+**New package: @mcpkit/server**
+
+- Introduces `createMcpServer()` fluent builder factory function
+- Provides chainable API methods: `.tool()`, `.prompt()`, `.resource()`, and `.use()`
+- The `.build()` method returns a complete McpRuntimeBundle containing both Registry and McpRuntime instances
+- Implements strict separation between declaration phase (builder methods) and execution phase (transport/middleware)
+
+This new package provides a convenient fluent API for building MCP servers, making it easier to configure and set up servers with tools, prompts, and resources in a chainable manner.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 ## TODO
 
  Add readme
+ 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # cli
 
-## 0.1.0
+## 0.0.0
 
 ### Patch Changes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @mcpkit/core
 
-## 0.1.2
+## 0.0.2
 
 ### Patch Changes
 
@@ -16,7 +16,7 @@
 
   This new package provides a convenient fluent API for building MCP servers, making it easier to configure and set up servers with tools, prompts, and resources in a chainable manner.
 
-## 0.1.1 – 2025-06-19
+## 0.0.1 – 2025-06-19
 
 ### Added
 
@@ -31,7 +31,7 @@
 
 - Vitest suite for schema parse / json round-trip.
 
-## 0.1.0
+## 0.0.0
 
 ### Patch Changes
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpkit/core",
-  "version": "0.1.2",
+  "version": "0.0.2",
   "description": "Core components for MCPKit",
   "keywords": [
     "mcpkit",

--- a/packages/core/src/schema/zod.ts
+++ b/packages/core/src/schema/zod.ts
@@ -1,5 +1,5 @@
 // packages/core/src/schema/zod.ts
-import type { ZodTypeAny, z } from 'zod';
+import { type ZodTypeAny, z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { Schema } from '.';
 
@@ -14,3 +14,5 @@ export class ZodSchema<T> implements Schema<T> {
 }
 
 export const s = <T>(zod: z.ZodType<T>): Schema<T> => new ZodSchema<T>(zod);
+
+export { z };

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # server
 
-## 0.1.0
+## 0.0.0
 
 ### Patch Changes
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,39 @@
+# @mcpkit/server
+
+A chainable builder API for creating MCP (Model Context Protocol) servers with type-safe tool, prompt, and resource registration.
+
+## Installation
+
+```bash
+npm install @mcpkit/server @mcpkit/core
+```
+
+## Quick Start
+
+```typescript
+import { createMcpServer, schema, z } from '@mcpkit/server';
+
+const server = createMcpServer()
+  .tool('add', {
+    input: schema(z.object({ a: z.number(), b: z.number() })),
+    output: schema(z.object({ result: z.number() })),
+    async handler({ a, b }) {
+      return { result: a + b };
+    }
+  })
+  .prompt('greeting', 'Hello {{name}}!', {
+    title: 'Greeting Template',
+    params: schema(z.object({ name: z.string() }))
+  })
+  .resource('readme', 'file://README.md', {
+    title: 'Project README'
+  })
+  .build();
+
+// Use the built server
+const result = await server.runtime.executeTool('add', { a: 2, b: 3 });
+console.log(result); // { result: 5 }
+
+const greeting = await server.runtime.renderPrompt('greeting', { name: 'Alice' });
+console.log(greeting); // "Hello Alice!"
+```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,19 +1,29 @@
 {
-  "name": "server",
-  "version": "0.1.0",
-  "description": "",
-  "main": "index.js",
+  "name": "@mcpkit/server",
+  "version": "0.0.1",
+  "description": "Chainable builder API for creating MCP servers",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:ci": "vitest run",
     "test:types": "echo 'No type definition tests for this package'",
     "lint": "npx @biomejs/biome check src",
     "typecheck": "tsc -p . --noEmit"
   },
-  "keywords": [],
+  "keywords": [
+    "mcpkit",
+    "server",
+    "builder",
+    "mcp"
+  ],
   "author": "Konstantin Simanov",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/GordonDrop/mcpkit.git",
@@ -22,5 +32,14 @@
   "bugs": {
     "url": "https://github.com/GordonDrop/mcpkit/issues"
   },
-  "homepage": "https://github.com/GordonDrop/mcpkit/tree/main/packages/server#readme"
+  "homepage": "https://github.com/GordonDrop/mcpkit/tree/main/packages/server#readme",
+  "peerDependencies": {
+    "@mcpkit/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@mcpkit/core": "workspace:^",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "zod": "^3.22.4"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpkit/server",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Chainable builder API for creating MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,5 +1,179 @@
-import { expect, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createMcpServer, schema, z } from './index';
 
-test('placeholder test', () => {
-  expect(1 + 1).toBe(2);
+describe('@mcpkit/server', () => {
+  describe('createMcpServer', () => {
+    it('should create a builder instance', () => {
+      const builder = createMcpServer();
+      expect(builder).toBeDefined();
+      expect(typeof builder.tool).toBe('function');
+      expect(typeof builder.prompt).toBe('function');
+      expect(typeof builder.resource).toBe('function');
+      expect(typeof builder.use).toBe('function');
+      expect(typeof builder.build).toBe('function');
+    });
+
+    it('should support chainable API', () => {
+      const builder = createMcpServer()
+        .tool('test-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `processed: ${input}`,
+        })
+        .prompt('test-prompt', 'Hello {{name}}!')
+        .resource('test-resource', 'file://test.txt');
+
+      expect(builder).toBeDefined();
+      expect(typeof builder.build).toBe('function');
+    });
+  });
+
+  describe('Compilation and type safety test', () => {
+    it('should compile and execute the example from requirements', async () => {
+      const server = createMcpServer()
+        .tool('add', {
+          input: schema(z.object({ a: z.number(), b: z.number() })),
+          output: schema(z.object({ result: z.number() })),
+          async handler({ a, b }) {
+            return { result: a + b };
+          },
+        })
+        .prompt('greeting', 'Hello {{name}}')
+        .resource('readme', 'file://README.md', { title: 'Project README' })
+        .build();
+
+      expect(server.registry).toBeDefined();
+      expect(server.runtime).toBeDefined();
+
+      const result = await server.runtime.executeTool('add', { a: 2, b: 3 });
+      expect(result).toEqual({ result: 5 });
+    });
+  });
+
+  describe('Duplicate name validation', () => {
+    it('should throw error for duplicate tool names', () => {
+      expect(() => {
+        createMcpServer()
+          .tool('duplicate', {
+            input: schema(z.string()),
+            output: schema(z.string()),
+            handler: async (input) => input,
+          })
+          .tool('duplicate', {
+            input: schema(z.number()),
+            output: schema(z.number()),
+            handler: async (input) => input,
+          })
+          .build();
+      }).toThrow("tool with name 'duplicate' already exists in registry");
+    });
+
+    it('should throw error for duplicate prompt names', () => {
+      expect(() => {
+        createMcpServer()
+          .prompt('duplicate', 'Template 1')
+          .prompt('duplicate', 'Template 2')
+          .build();
+      }).toThrow("prompt with name 'duplicate' already exists in registry");
+    });
+
+    it('should throw error for duplicate resource names', () => {
+      expect(() => {
+        createMcpServer()
+          .resource('duplicate', 'file://test1.txt')
+          .resource('duplicate', 'file://test2.txt')
+          .build();
+      }).toThrow("resource with name 'duplicate' already exists in registry");
+    });
+
+    it('should not throw error for duplicate names across different types', () => {
+      expect(() => {
+        createMcpServer()
+          .tool('duplicate', {
+            input: schema(z.string()),
+            output: schema(z.string()),
+            handler: async (input) => input,
+          })
+          .prompt('duplicate', 'Template')
+          .build();
+      }).not.toThrow();
+    });
+  });
+
+  describe('Runtime execution', () => {
+    let server: ReturnType<ReturnType<typeof createMcpServer>['build']>;
+
+    beforeEach(() => {
+      server = createMcpServer()
+        .tool('echo', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `echo: ${input}`,
+        })
+        .tool('math', {
+          input: schema(z.object({ x: z.number(), y: z.number() })),
+          output: schema(z.object({ sum: z.number(), product: z.number() })),
+          handler: async ({ x, y }) => ({ sum: x + y, product: x * y }),
+        })
+        .prompt('greeting', 'Hello {{name}}!', {
+          params: schema(z.object({ name: z.string() })),
+        })
+        .resource('config', 'file://config.json', { title: 'Configuration' })
+        .build();
+    });
+
+    it('should execute tools correctly', async () => {
+      const echoResult = await server.runtime.executeTool('echo', 'test');
+      expect(echoResult).toBe('echo: test');
+
+      const mathResult = await server.runtime.executeTool('math', { x: 5, y: 3 });
+      expect(mathResult).toEqual({ sum: 8, product: 15 });
+    });
+
+    it('should render prompts correctly', async () => {
+      const result = await server.runtime.renderPrompt('greeting', { name: 'Alice' });
+      expect(result).toBe('Hello Alice!');
+    });
+
+    it('should have registered entities in registry', () => {
+      expect(server.registry.hasTool('echo')).toBe(true);
+      expect(server.registry.hasTool('math')).toBe(true);
+      expect(server.registry.hasPrompt('greeting')).toBe(true);
+      expect(server.registry.hasResource('config')).toBe(true);
+
+      expect(server.registry.getToolNames()).toContain('echo');
+      expect(server.registry.getToolNames()).toContain('math');
+      expect(server.registry.getPromptNames()).toContain('greeting');
+      expect(server.registry.getResourceNames()).toContain('config');
+    });
+  });
+
+  describe('Middleware no-op', () => {
+    it('should accept middleware but not affect runtime behavior', async () => {
+      const server = createMcpServer()
+        .use('some-middleware')
+        .use({ type: 'middleware', config: {} })
+        .tool('test', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `result: ${input}`,
+        })
+        .build();
+
+      const result = await server.runtime.executeTool('test', 'input');
+      expect(result).toBe('result: input');
+    });
+  });
+
+  describe('Re-exports', () => {
+    it('should re-export z and schema from @mcpkit/core', () => {
+      expect(z).toBeDefined();
+      expect(schema).toBeDefined();
+      expect(typeof schema).toBe('function');
+
+      const testSchema = schema(z.string());
+      expect(testSchema.parse('test')).toBe('test');
+      expect(() => testSchema.parse(123)).toThrow();
+    });
+  });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,125 @@
-// placeholder
+import {
+  Registry as CoreRegistry,
+  createMcpRuntime,
+  type ExecutionCtx,
+  type McpRuntime,
+  NameConflictError,
+  type PromptSpec,
+  type Registry,
+  type ResourceSpec,
+  s as schema,
+  type ToolSpec,
+  z,
+} from '@mcpkit/core';
+
+export { schema, z };
+
+export interface McpServerBuilder {
+  tool<I, O>(name: string, definition: Omit<ToolSpec<I, O>, 'name'>): McpServerBuilder;
+
+  prompt<P>(
+    name: string,
+    template: string,
+    metadata?: Partial<Omit<PromptSpec<P>, 'name' | 'template'>>,
+  ): McpServerBuilder;
+
+  resource(
+    name: string,
+    uri: string,
+    metadata?: Partial<Omit<ResourceSpec, 'name' | 'uri'>>,
+  ): McpServerBuilder;
+
+  use(middleware: unknown): McpServerBuilder;
+  build(): McpRuntimeBundle;
+}
+
+export interface McpRuntimeBundle {
+  registry: Registry;
+  runtime: McpRuntime;
+}
+
+class McpServerBuilderImpl implements McpServerBuilder {
+  private readonly pendingTools: ToolSpec[] = [];
+  private readonly pendingPrompts: PromptSpec[] = [];
+  private readonly pendingResources: ResourceSpec[] = [];
+
+  tool<I, O>(name: string, definition: Omit<ToolSpec<I, O>, 'name'>): McpServerBuilder {
+    const tool: ToolSpec<I, O> = {
+      name,
+      ...definition,
+    };
+    this.pendingTools.push(tool);
+    return this;
+  }
+
+  prompt<P>(
+    name: string,
+    template: string,
+    metadata?: Partial<Omit<PromptSpec<P>, 'name' | 'template'>>,
+  ): McpServerBuilder {
+    const prompt: PromptSpec<P> = {
+      name,
+      template,
+      ...metadata,
+    };
+    this.pendingPrompts.push(prompt);
+    return this;
+  }
+
+  resource(
+    name: string,
+    uri: string,
+    metadata?: Partial<Omit<ResourceSpec, 'name' | 'uri'>>,
+  ): McpServerBuilder {
+    const resource: ResourceSpec = {
+      name,
+      uri,
+      ...metadata,
+    };
+    this.pendingResources.push(resource);
+    return this;
+  }
+
+  use(_middleware: unknown): McpServerBuilder {
+    return this;
+  }
+
+  build(): McpRuntimeBundle {
+    const registry = new CoreRegistry();
+
+    const allNames = new Set<string>();
+
+    for (const tool of this.pendingTools) {
+      allNames.add(tool.name);
+      registry.addTool(tool);
+    }
+
+    for (const prompt of this.pendingPrompts) {
+      allNames.add(prompt.name);
+      registry.addPrompt(prompt);
+    }
+
+    for (const resource of this.pendingResources) {
+      allNames.add(resource.name);
+      registry.addResource(resource);
+    }
+
+    const executionCtx: ExecutionCtx = {
+      logger: {
+        info: (obj: object, msg?: string) => console.log(msg || '', obj),
+        warn: (obj: object, msg?: string) => console.warn(msg || '', obj),
+        error: (obj: object, msg?: string) => console.error(msg || '', obj),
+        debug: (obj: object, msg?: string) => console.debug(msg || '', obj),
+      },
+      version: '1.0.0',
+    };
+
+    const runtime = createMcpRuntime(registry, executionCtx);
+
+    return { registry, runtime };
+  }
+}
+
+export function createMcpServer(_options?: unknown): McpServerBuilder {
+  return new McpServerBuilderImpl();
+}

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "tests/**/*"]
+}

--- a/packages/transport-stdio/CHANGELOG.md
+++ b/packages/transport-stdio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # transport-stdio
 
-## 0.1.0
+## 0.0.0
 
 ### Patch Changes
 

--- a/packages/transport-stdio/package.json
+++ b/packages/transport-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transport-stdio",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,20 @@ importers:
         specifier: ^8.0.2
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0)
 
-  packages/server: {}
+  packages/server:
+    devDependencies:
+      '@mcpkit/core':
+        specifier: workspace:^
+        version: link:../core
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.1)
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.67
 
   packages/transport-stdio: {}
 


### PR DESCRIPTION
**New package: @mcpkit/server**

- Introduces `createMcpServer()` fluent builder factory function
- Provides chainable API methods: `.tool()`, `.prompt()`, `.resource()`, and `.use()`
- The `.build()` method returns a complete McpRuntimeBundle containing both Registry and McpRuntime instances
- Implements strict separation between declaration phase (builder methods) and execution phase (transport/middleware)

This new package provides a convenient fluent API for building MCP servers, making it easier to configure and set up servers with tools, prompts, and resources in a chainable manner.