### PR TITLE
feat: add error wrapper middleware and comprehensive tests

### DIFF
--- a/packages/server/src/__tests__/internal/compose.test.ts
+++ b/packages/server/src/__tests__/internal/compose.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from 'vitest';
+import { composeMiddlewares } from '../../internal/compose';
+import type { CallCtx, InvokeFn, Middleware } from '../../middleware/types';
+
+describe('Middleware Composition', () => {
+  const mockCtx: CallCtx = {
+    type: 'tool',
+    name: 'test-tool',
+    input: 'test-input',
+    meta: { start: BigInt(Date.now()) },
+  };
+
+  const mockCoreInvoker: InvokeFn = async (ctx) => ({
+    content: `core-result-${ctx.input}`,
+  });
+
+  describe('Edge Cases', () => {
+    it('should return core function when no middlewares provided', async () => {
+      const composed = composeMiddlewares([], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'core-result-test-input' });
+    });
+
+    it('should handle undefined middleware array gracefully', async () => {
+      const composed = composeMiddlewares([], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'core-result-test-input' });
+    });
+  });
+
+  describe('Single Middleware', () => {
+    it('should compose single middleware correctly', async () => {
+      const middleware: Middleware = (next) => async (ctx) => {
+        const result = await next(ctx);
+        return {
+          content: `middleware-${result.content}`,
+        };
+      };
+
+      const composed = composeMiddlewares([middleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'middleware-core-result-test-input' });
+    });
+
+    it('should allow middleware to modify context', async () => {
+      const middleware: Middleware = (next) => async (ctx) => {
+        const modifiedCtx = {
+          ...ctx,
+          input: `modified-${ctx.input}`,
+        };
+        return await next(modifiedCtx);
+      };
+
+      const composed = composeMiddlewares([middleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'core-result-modified-test-input' });
+    });
+
+    it('should allow middleware to short-circuit execution', async () => {
+      const shortCircuitMiddleware: Middleware = () => async () => ({
+        content: 'short-circuited',
+        isError: false,
+      });
+
+      const composed = composeMiddlewares([shortCircuitMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'short-circuited', isError: false });
+    });
+  });
+
+  describe('Multiple Middleware Composition', () => {
+    it('should compose multiple middlewares in correct order (onion model)', async () => {
+      const executionOrder: string[] = [];
+
+      const middleware1: Middleware = (next) => async (ctx) => {
+        executionOrder.push('middleware1-before');
+        const result = await next(ctx);
+        executionOrder.push('middleware1-after');
+        return {
+          content: `m1[${result.content}]`,
+        };
+      };
+
+      const middleware2: Middleware = (next) => async (ctx) => {
+        executionOrder.push('middleware2-before');
+        const result = await next(ctx);
+        executionOrder.push('middleware2-after');
+        return {
+          content: `m2[${result.content}]`,
+        };
+      };
+
+      const middleware3: Middleware = (next) => async (ctx) => {
+        executionOrder.push('middleware3-before');
+        const result = await next(ctx);
+        executionOrder.push('middleware3-after');
+        return {
+          content: `m3[${result.content}]`,
+        };
+      };
+
+      const coreWithLogging: InvokeFn = async (ctx) => {
+        executionOrder.push('core');
+        return { content: `core-${ctx.input}` };
+      };
+
+      const composed = composeMiddlewares([middleware1, middleware2, middleware3], coreWithLogging);
+      const result = await composed(mockCtx);
+
+      expect(executionOrder).toEqual([
+        'middleware1-before',
+        'middleware2-before',
+        'middleware3-before',
+        'core',
+        'middleware3-after',
+        'middleware2-after',
+        'middleware1-after',
+      ]);
+
+      expect(result).toEqual({ content: 'm1[m2[m3[core-test-input]]]' });
+    });
+
+    it('should handle async middleware correctly', async () => {
+      const asyncMiddleware1: Middleware = (next) => async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        const result = await next(ctx);
+        return { content: `async1[${result.content}]` };
+      };
+
+      const asyncMiddleware2: Middleware = (next) => async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        const result = await next(ctx);
+        return { content: `async2[${result.content}]` };
+      };
+
+      const composed = composeMiddlewares([asyncMiddleware1, asyncMiddleware2], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result).toEqual({ content: 'async1[async2[core-result-test-input]]' });
+    });
+  });
+
+  describe('Error Propagation', () => {
+    it('should propagate errors from core function', async () => {
+      const errorCore: InvokeFn = async () => {
+        throw new Error('Core error');
+      };
+
+      const middleware: Middleware = (next) => async (ctx) => {
+        return await next(ctx);
+      };
+
+      const composed = composeMiddlewares([middleware], errorCore);
+
+      await expect(composed(mockCtx)).rejects.toThrow('Core error');
+    });
+
+    it('should propagate errors from middleware', async () => {
+      const errorMiddleware: Middleware = () => async () => {
+        throw new Error('Middleware error');
+      };
+
+      const composed = composeMiddlewares([errorMiddleware], mockCoreInvoker);
+
+      await expect(composed(mockCtx)).rejects.toThrow('Middleware error');
+    });
+
+    it('should allow middleware to catch and handle errors', async () => {
+      const errorCore: InvokeFn = async () => {
+        throw new Error('Core error');
+      };
+
+      const errorHandlingMiddleware: Middleware = (next) => async (ctx) => {
+        try {
+          return await next(ctx);
+        } catch (error) {
+          return {
+            content: error,
+            isError: true,
+          };
+        }
+      };
+
+      const composed = composeMiddlewares([errorHandlingMiddleware], errorCore);
+      const result = await composed(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBeInstanceOf(Error);
+      expect((result.content as Error).message).toBe('Core error');
+    });
+  });
+
+  describe('Performance and Edge Cases', () => {
+    it('should handle very deep middleware chains efficiently', async () => {
+      const middlewares: Middleware[] = [];
+
+      // Create 1000 middleware functions
+      for (let i = 0; i < 1000; i++) {
+        middlewares.push((next) => async (ctx) => {
+          const result = await next(ctx);
+          return { content: `${i}:${result.content}` };
+        });
+      }
+
+      const composed = composeMiddlewares(middlewares, mockCoreInvoker);
+      const start = Date.now();
+      const result = await composed(mockCtx);
+      const duration = Date.now() - start;
+
+      expect(result.content).toContain('core-result-test-input');
+      expect(result.content).toContain('0:');
+      expect(result.content).toContain('999:');
+      expect(duration).toBeLessThan(1000); // Should complete within 1 second
+    });
+
+    it('should handle middleware that returns different result structures', async () => {
+      const customResultMiddleware: Middleware = (next) => async (ctx) => {
+        const result = await next(ctx);
+        return {
+          content: result.content,
+          isError: false,
+          timestamp: Date.now(),
+          metadata: { processed: true },
+        };
+      };
+
+      const composed = composeMiddlewares([customResultMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toBe('core-result-test-input');
+      expect(result.isError).toBe(false);
+      expect(result).toHaveProperty('timestamp');
+      expect(result).toHaveProperty('metadata');
+      expect((result as unknown as { metadata: { processed: boolean } }).metadata.processed).toBe(
+        true,
+      );
+    });
+
+    it('should handle middleware with complex async patterns', async () => {
+      const asyncPatternMiddleware: Middleware = (next) => async (ctx) => {
+        // Simulate complex async operations
+        const [result1, result2] = await Promise.all([
+          next(ctx),
+          new Promise((resolve) => setTimeout(() => resolve('async-data'), 10)),
+        ]);
+
+        return {
+          content: `${result1.content}-${result2}`,
+        };
+      };
+
+      const composed = composeMiddlewares([asyncPatternMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toBe('core-result-test-input-async-data');
+    });
+
+    it('should maintain proper this context in middleware', async () => {
+      class MiddlewareClass {
+        prefix = 'class-prefix';
+
+        createMiddleware(): Middleware {
+          return (next) => async (ctx) => {
+            const result = await next(ctx);
+            return {
+              content: `${this.prefix}-${result.content}`,
+            };
+          };
+        }
+      }
+
+      const instance = new MiddlewareClass();
+      const middleware = instance.createMiddleware();
+
+      const composed = composeMiddlewares([middleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toBe('class-prefix-core-result-test-input');
+    });
+  });
+
+  describe('Loop Prevention and Stack Safety', () => {
+    it('should handle middleware that calls next multiple times', async () => {
+      let coreCallCount = 0;
+
+      const multipleCallMiddleware: Middleware = (next) => async (ctx) => {
+        const result1 = await next(ctx);
+        const result2 = await next(ctx); // Second call to next
+        return {
+          content: `${result1.content}-${result2.content}`,
+        };
+      };
+
+      const countingCore: InvokeFn = async (ctx) => {
+        coreCallCount++;
+        return { content: `core-${coreCallCount}-${ctx.input}` };
+      };
+
+      const composed = composeMiddlewares([multipleCallMiddleware], countingCore);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toBe('core-1-test-input-core-2-test-input');
+      expect(coreCallCount).toBe(2);
+    });
+
+    it('should handle middleware that attempts to create circular calls', async () => {
+      let callDepth = 0;
+      const maxDepth = 5;
+
+      const circularMiddleware: Middleware = (next) => async (ctx) => {
+        callDepth++;
+
+        if (callDepth > maxDepth) {
+          return { content: 'max-depth-reached', isError: true };
+        }
+
+        // Simulate a middleware that might try to call itself indirectly
+        const result = await next(ctx);
+
+        if (callDepth < 3) {
+          // Try to call next again (simulating potential loop)
+          const secondResult = await next({
+            ...ctx,
+            input: `recursive-${ctx.input}`,
+          });
+          return { content: `${result.content}-${secondResult.content}` };
+        }
+
+        return result;
+      };
+
+      const composed = composeMiddlewares([circularMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(callDepth).toBeLessThanOrEqual(maxDepth);
+      expect(result.content).toContain('core-result');
+    });
+
+    it('should handle deeply nested middleware without stack overflow', async () => {
+      const deepMiddlewares: Middleware[] = [];
+      const depth = 500; // Test with 500 levels of nesting
+
+      // Create middleware that each add a level of nesting
+      for (let i = 0; i < depth; i++) {
+        deepMiddlewares.push((next) => async (ctx) => {
+          const result = await next(ctx);
+          return { content: `[${i}:${result.content}]` };
+        });
+      }
+
+      const composed = composeMiddlewares(deepMiddlewares, mockCoreInvoker);
+
+      // This should not cause a stack overflow
+      const result = await composed(mockCtx);
+
+      expect(result.content).toContain('core-result-test-input');
+      expect(result.content).toContain('[0:');
+      expect(result.content).toContain(`[${depth - 1}:`);
+    });
+
+    it('should handle middleware that modifies the next function', async () => {
+      const modifyingMiddleware: Middleware = (next) => {
+        // Create a wrapped version of next that adds tracking
+        const wrappedNext: InvokeFn = async (ctx) => {
+          const modifiedCtx = {
+            ...ctx,
+            input: `wrapped-${ctx.input}`,
+          };
+          return await next(modifiedCtx);
+        };
+
+        return async (ctx) => {
+          return await wrappedNext(ctx);
+        };
+      };
+
+      const composed = composeMiddlewares([modifyingMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toBe('core-result-wrapped-test-input');
+    });
+
+    it('should handle middleware with recursive async patterns safely', async () => {
+      let recursionDepth = 0;
+      const maxRecursion = 10;
+
+      const recursiveAsyncMiddleware: Middleware = (next) => async (ctx) => {
+        recursionDepth++;
+
+        if (recursionDepth > maxRecursion) {
+          return { content: 'recursion-limit-reached', isError: true };
+        }
+
+        // Simulate recursive async pattern
+        const processRecursively = async (input: unknown, depth: number): Promise<unknown> => {
+          if (depth <= 0) {
+            return input;
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return await processRecursively(`processed-${input}`, depth - 1);
+        };
+
+        const processedInput = await processRecursively(ctx.input, 3);
+        const modifiedCtx = { ...ctx, input: processedInput };
+
+        const result = await next(modifiedCtx);
+        recursionDepth--;
+
+        return result;
+      };
+
+      const composed = composeMiddlewares([recursiveAsyncMiddleware], mockCoreInvoker);
+      const result = await composed(mockCtx);
+
+      expect(result.content).toContain('processed-processed-processed-test-input');
+      expect(recursionDepth).toBe(0); // Should return to 0 after completion
+    });
+
+    it('should detect and handle potential infinite loops in middleware', async () => {
+      let executionCount = 0;
+      const maxExecutions = 10;
+
+      const potentialLoopMiddleware: Middleware = (next) => async (ctx) => {
+        executionCount++;
+
+        // Safety check to prevent actual infinite loop in test
+        if (executionCount > maxExecutions) {
+          throw new Error('Potential infinite loop detected');
+        }
+
+        // Simulate middleware that might cause issues by recursively calling itself
+        if (ctx.input === 'trigger-loop' && executionCount <= maxExecutions) {
+          // Create a new middleware instance and call it (simulating loop)
+          const recursiveMiddleware = potentialLoopMiddleware(next);
+          return await recursiveMiddleware(ctx);
+        }
+
+        return await next(ctx);
+      };
+
+      const loopCtx = { ...mockCtx, input: 'trigger-loop' };
+
+      await expect(async () => {
+        const composed = composeMiddlewares([potentialLoopMiddleware], mockCoreInvoker);
+        await composed(loopCtx);
+      }).rejects.toThrow('Potential infinite loop detected');
+
+      expect(executionCount).toBeGreaterThan(maxExecutions);
+    });
+  });
+});

--- a/packages/server/src/__tests__/middleware/builtin-error-wrapper.test.ts
+++ b/packages/server/src/__tests__/middleware/builtin-error-wrapper.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { errorWrapperMiddleware } from '../../middleware/builtin-error-wrapper';
+import type { CallCtx, InvokeFn } from '../../middleware/types';
+
+describe('Error Wrapper Middleware', () => {
+  const mockCtx: CallCtx = {
+    type: 'tool',
+    name: 'test-tool',
+    input: 'test-input',
+    meta: { start: BigInt(Date.now()) },
+  };
+
+  describe('Successful Execution', () => {
+    it('should pass through successful results unchanged', async () => {
+      const successfulNext: InvokeFn = async () => ({
+        content: 'success-result',
+      });
+
+      const wrappedNext = errorWrapperMiddleware(successfulNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result).toEqual({ content: 'success-result' });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should preserve existing result properties', async () => {
+      const successfulNext: InvokeFn = async () => ({
+        content: 'success-result',
+        isError: false,
+        customProperty: 'custom-value',
+      });
+
+      const wrappedNext = errorWrapperMiddleware(successfulNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result).toEqual({
+        content: 'success-result',
+        isError: false,
+        customProperty: 'custom-value',
+      });
+    });
+
+    it('should handle async operations correctly', async () => {
+      const asyncNext: InvokeFn = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return { content: 'async-result' };
+      };
+
+      const wrappedNext = errorWrapperMiddleware(asyncNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result).toEqual({ content: 'async-result' });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should catch and wrap thrown errors', async () => {
+      const errorNext: InvokeFn = async () => {
+        throw new Error('Test error message');
+      };
+
+      const wrappedNext = errorWrapperMiddleware(errorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBeInstanceOf(Error);
+      expect((result.content as Error).message).toBe('Test error message');
+    });
+
+    it('should handle different error types', async () => {
+      const typeErrorNext: InvokeFn = async () => {
+        throw new TypeError('Type error message');
+      };
+
+      const wrappedNext = errorWrapperMiddleware(typeErrorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBeInstanceOf(TypeError);
+      expect((result.content as TypeError).message).toBe('Type error message');
+    });
+
+    it('should handle string errors', async () => {
+      const stringErrorNext: InvokeFn = async () => {
+        throw 'String error';
+      };
+
+      const wrappedNext = errorWrapperMiddleware(stringErrorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe('String error');
+    });
+
+    it('should handle null/undefined errors', async () => {
+      const nullErrorNext: InvokeFn = async () => {
+        throw null;
+      };
+
+      const wrappedNext = errorWrapperMiddleware(nullErrorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(null);
+    });
+
+    it('should handle object errors', async () => {
+      const objectError = { code: 'CUSTOM_ERROR', message: 'Custom error' };
+      const objectErrorNext: InvokeFn = async () => {
+        throw objectError;
+      };
+
+      const wrappedNext = errorWrapperMiddleware(objectErrorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual(objectError);
+    });
+  });
+
+  describe('Error Result Structure', () => {
+    it('should create proper error result structure', async () => {
+      const errorNext: InvokeFn = async () => {
+        throw new Error('Test error');
+      };
+
+      const wrappedNext = errorWrapperMiddleware(errorNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result).toHaveProperty('content');
+      expect(Object.keys(result)).toEqual(['isError', 'content']);
+    });
+
+    it('should not modify error results that are already wrapped', async () => {
+      const alreadyWrappedNext: InvokeFn = async () => ({
+        isError: true,
+        content: new Error('Already wrapped'),
+      });
+
+      const wrappedNext = errorWrapperMiddleware(alreadyWrappedNext);
+      const result = await wrappedNext(mockCtx);
+
+      expect(result).toEqual({
+        isError: true,
+        content: new Error('Already wrapped'),
+      });
+    });
+  });
+
+  describe('Context Preservation', () => {
+    it('should pass context through to next function', async () => {
+      let receivedCtx: CallCtx | null = null;
+
+      const contextCapturingNext: InvokeFn = async (ctx) => {
+        receivedCtx = ctx;
+        return { content: 'result' };
+      };
+
+      const wrappedNext = errorWrapperMiddleware(contextCapturingNext);
+      await wrappedNext(mockCtx);
+
+      expect(receivedCtx).toEqual(mockCtx);
+    });
+
+    it('should preserve context modifications in error cases', async () => {
+      let receivedCtx: CallCtx | null = null;
+
+      const contextCapturingErrorNext: InvokeFn = async (ctx) => {
+        receivedCtx = ctx;
+        throw new Error('Test error');
+      };
+
+      const wrappedNext = errorWrapperMiddleware(contextCapturingErrorNext);
+      await wrappedNext(mockCtx);
+
+      expect(receivedCtx).toEqual(mockCtx);
+    });
+  });
+});

--- a/packages/server/src/__tests__/middleware/types.test.ts
+++ b/packages/server/src/__tests__/middleware/types.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import type { CallCtx, CallResult, InvokeFn, Middleware } from '../../middleware/types';
+
+describe('Middleware Types', () => {
+  describe('CallCtx Interface', () => {
+    it('should accept valid CallCtx objects', () => {
+      const validCtx: CallCtx = {
+        type: 'tool',
+        name: 'test-tool',
+        input: 'test-input',
+        meta: { start: BigInt(Date.now()) },
+      };
+
+      expect(validCtx.type).toBe('tool');
+      expect(validCtx.name).toBe('test-tool');
+      expect(validCtx.input).toBe('test-input');
+      expect(typeof validCtx.meta.start).toBe('bigint');
+    });
+
+    it('should support all operation types', () => {
+      const toolCtx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: {},
+        meta: { start: BigInt(0) },
+      };
+
+      const promptCtx: CallCtx = {
+        type: 'prompt',
+        name: 'test',
+        input: {},
+        meta: { start: BigInt(0) },
+      };
+
+      const resourceCtx: CallCtx = {
+        type: 'resource',
+        name: 'test',
+        input: {},
+        meta: { start: BigInt(0) },
+      };
+
+      expect(toolCtx.type).toBe('tool');
+      expect(promptCtx.type).toBe('prompt');
+      expect(resourceCtx.type).toBe('resource');
+    });
+
+    it('should support different input types', () => {
+      const stringInputCtx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: 'string-input',
+        meta: { start: BigInt(0) },
+      };
+
+      const objectInputCtx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: { key: 'value', number: 42 },
+        meta: { start: BigInt(0) },
+      };
+
+      const arrayInputCtx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: [1, 2, 3],
+        meta: { start: BigInt(0) },
+      };
+
+      expect(stringInputCtx.input).toBe('string-input');
+      expect(objectInputCtx.input).toEqual({ key: 'value', number: 42 });
+      expect(arrayInputCtx.input).toEqual([1, 2, 3]);
+    });
+
+    it('should support bigint timestamps for high precision', () => {
+      const highPrecisionStart = process.hrtime.bigint();
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: null,
+        meta: { start: highPrecisionStart },
+      };
+
+      expect(typeof ctx.meta.start).toBe('bigint');
+      expect(ctx.meta.start).toBe(highPrecisionStart);
+    });
+  });
+
+  describe('CallResult Interface', () => {
+    it('should accept valid CallResult objects', () => {
+      const successResult: CallResult = {
+        content: 'success-content',
+      };
+
+      const errorResult: CallResult = {
+        content: new Error('error-content'),
+        isError: true,
+      };
+
+      expect(successResult.content).toBe('success-content');
+      expect(successResult.isError).toBeUndefined();
+      expect(errorResult.content).toBeInstanceOf(Error);
+      expect(errorResult.isError).toBe(true);
+    });
+
+    it('should support different content types', () => {
+      const stringResult: CallResult = { content: 'string' };
+      const numberResult: CallResult = { content: 42 };
+      const objectResult: CallResult = { content: { key: 'value' } };
+      const arrayResult: CallResult = { content: [1, 2, 3] };
+      const nullResult: CallResult = { content: null };
+
+      expect(stringResult.content).toBe('string');
+      expect(numberResult.content).toBe(42);
+      expect(objectResult.content).toEqual({ key: 'value' });
+      expect(arrayResult.content).toEqual([1, 2, 3]);
+      expect(nullResult.content).toBe(null);
+    });
+
+    it('should make isError optional', () => {
+      const resultWithoutError: CallResult = { content: 'test' };
+      const resultWithError: CallResult = { content: 'test', isError: false };
+      const errorResult: CallResult = { content: 'test', isError: true };
+
+      expect('isError' in resultWithoutError).toBe(false);
+      expect(resultWithError.isError).toBe(false);
+      expect(errorResult.isError).toBe(true);
+    });
+  });
+
+  describe('InvokeFn Type', () => {
+    it('should accept functions with correct signature', async () => {
+      const validInvokeFn: InvokeFn = async (ctx: CallCtx) => ({
+        content: `processed-${ctx.name}`,
+      });
+
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: 'input',
+        meta: { start: BigInt(0) },
+      };
+
+      const result = await validInvokeFn(ctx);
+      expect(result.content).toBe('processed-test');
+    });
+
+    it('should return Promise<CallResult>', async () => {
+      const asyncInvokeFn: InvokeFn = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return { content: 'async-result' };
+      };
+
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: null,
+        meta: { start: BigInt(0) },
+      };
+
+      const result = await asyncInvokeFn(ctx);
+      expect(result).toEqual({ content: 'async-result' });
+    });
+  });
+
+  describe('Middleware Type', () => {
+    it('should accept functions with correct signature', async () => {
+      const validMiddleware: Middleware = (next: InvokeFn) => async (ctx: CallCtx) => {
+        const result = await next(ctx);
+        return {
+          content: `middleware-${result.content}`,
+        };
+      };
+
+      const mockNext: InvokeFn = async () => ({ content: 'next-result' });
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: null,
+        meta: { start: BigInt(0) },
+      };
+
+      const wrappedFn = validMiddleware(mockNext);
+      const result = await wrappedFn(ctx);
+
+      expect(result.content).toBe('middleware-next-result');
+    });
+
+    it('should support middleware that modifies context', async () => {
+      const contextModifyingMiddleware: Middleware = (next) => async (ctx) => {
+        const modifiedCtx = {
+          ...ctx,
+          input: `modified-${ctx.input}`,
+        };
+        return await next(modifiedCtx);
+      };
+
+      const mockNext: InvokeFn = async (ctx) => ({ content: ctx.input });
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: 'original',
+        meta: { start: BigInt(0) },
+      };
+
+      const wrappedFn = contextModifyingMiddleware(mockNext);
+      const result = await wrappedFn(ctx);
+
+      expect(result.content).toBe('modified-original');
+    });
+
+    it('should support middleware that short-circuits', async () => {
+      const shortCircuitMiddleware: Middleware = () => async () => ({
+        content: 'short-circuited',
+        isError: false,
+      });
+
+      const mockNext: InvokeFn = async () => ({ content: 'should-not-reach' });
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: null,
+        meta: { start: BigInt(0) },
+      };
+
+      const wrappedFn = shortCircuitMiddleware(mockNext);
+      const result = await wrappedFn(ctx);
+
+      expect(result.content).toBe('short-circuited');
+    });
+  });
+
+  describe('Type Composition', () => {
+    it('should allow complex middleware composition', async () => {
+      const middleware1: Middleware = (next) => async (ctx) => {
+        const result = await next(ctx);
+        return { content: `m1[${result.content}]` };
+      };
+
+      const middleware2: Middleware = (next) => async (ctx) => {
+        const result = await next(ctx);
+        return { content: `m2[${result.content}]` };
+      };
+
+      const core: InvokeFn = async (ctx) => ({ content: `core-${ctx.name}` });
+      const ctx: CallCtx = {
+        type: 'tool',
+        name: 'test',
+        input: null,
+        meta: { start: BigInt(0) },
+      };
+
+      const composed = middleware1(middleware2(core));
+      const result = await composed(ctx);
+
+      expect(result.content).toBe('m1[m2[core-test]]');
+    });
+  });
+});

--- a/packages/server/src/__tests__/plugin/index.test.ts
+++ b/packages/server/src/__tests__/plugin/index.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import { createMcpServer, type Plugin, schema, z } from '../../index';
+
+describe('Plugin System', () => {
+  describe('Plugin Contract', () => {
+    it('should accept plugins with correct signature', () => {
+      const testPlugin: Plugin = (srv) => {
+        srv.tool('plugin-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `plugin: ${input}`,
+        });
+      };
+
+      expect(() => {
+        createMcpServer().register(testPlugin).build();
+      }).not.toThrow();
+    });
+
+    it('should accept plugins with typed options', () => {
+      interface PluginOptions {
+        prefix: string;
+        enabled: boolean;
+      }
+
+      const typedPlugin: Plugin<PluginOptions> = (srv, opts) => {
+        if (opts?.enabled) {
+          srv.tool('typed-tool', {
+            input: schema(z.string()),
+            output: schema(z.string()),
+            handler: async (input) => `${opts.prefix}: ${input}`,
+          });
+        }
+      };
+
+      const server = createMcpServer()
+        .register(typedPlugin, { prefix: 'test', enabled: true })
+        .build();
+
+      expect(server.registry.hasTool('typed-tool')).toBe(true);
+    });
+
+    it('should handle plugins without options', () => {
+      const simplePlugin: Plugin = (srv) => {
+        srv.prompt('plugin-prompt', 'Hello {{name}}!');
+      };
+
+      const server = createMcpServer().register(simplePlugin).build();
+
+      expect(server.registry.hasPrompt('plugin-prompt')).toBe(true);
+    });
+  });
+
+  describe('Plugin Execution', () => {
+    it('should execute plugins during build phase', () => {
+      let pluginExecuted = false;
+
+      const executionPlugin: Plugin = () => {
+        pluginExecuted = true;
+      };
+
+      createMcpServer().register(executionPlugin).build();
+
+      expect(pluginExecuted).toBe(true);
+    });
+
+    it('should pass builder instance to plugins', () => {
+      let receivedBuilder: any = null;
+
+      const builderPlugin: Plugin = (srv) => {
+        receivedBuilder = srv;
+      };
+
+      const originalBuilder = createMcpServer().register(builderPlugin);
+      originalBuilder.build();
+
+      expect(receivedBuilder).toBeDefined();
+      expect(typeof receivedBuilder.tool).toBe('function');
+      expect(typeof receivedBuilder.prompt).toBe('function');
+      expect(typeof receivedBuilder.resource).toBe('function');
+      expect(typeof receivedBuilder.use).toBe('function');
+      expect(typeof receivedBuilder.register).toBe('function');
+    });
+
+    it('should pass options to plugins correctly', () => {
+      let receivedOptions: any = null;
+
+      const optionsPlugin: Plugin<{ test: string; number: number }> = (srv, opts) => {
+        receivedOptions = opts;
+      };
+
+      const testOptions = { test: 'value', number: 42 };
+      createMcpServer().register(optionsPlugin, testOptions).build();
+
+      expect(receivedOptions).toEqual(testOptions);
+    });
+  });
+
+  describe('Plugin Composition', () => {
+    it('should execute multiple plugins in registration order', () => {
+      const executionOrder: string[] = [];
+
+      const plugin1: Plugin = () => {
+        executionOrder.push('plugin1');
+      };
+
+      const plugin2: Plugin = () => {
+        executionOrder.push('plugin2');
+      };
+
+      const plugin3: Plugin = () => {
+        executionOrder.push('plugin3');
+      };
+
+      createMcpServer().register(plugin1).register(plugin2).register(plugin3).build();
+
+      expect(executionOrder).toEqual(['plugin1', 'plugin2', 'plugin3']);
+    });
+
+    it('should allow plugins to add different types of entities', () => {
+      const toolPlugin: Plugin = (srv) => {
+        srv.tool('plugin-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => input,
+        });
+      };
+
+      const promptPlugin: Plugin = (srv) => {
+        srv.prompt('plugin-prompt', 'Template');
+      };
+
+      const resourcePlugin: Plugin = (srv) => {
+        srv.resource('plugin-resource', 'file://test.txt');
+      };
+
+      const middlewarePlugin: Plugin = (srv) => {
+        srv.use((next) => async (ctx) => await next(ctx));
+      };
+
+      const server = createMcpServer()
+        .register(toolPlugin)
+        .register(promptPlugin)
+        .register(resourcePlugin)
+        .register(middlewarePlugin)
+        .build();
+
+      expect(server.registry.hasTool('plugin-tool')).toBe(true);
+      expect(server.registry.hasPrompt('plugin-prompt')).toBe(true);
+      expect(server.registry.hasResource('plugin-resource')).toBe(true);
+    });
+
+    it('should allow plugins to register other plugins', () => {
+      const nestedPlugin: Plugin = (srv) => {
+        srv.tool('nested-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `nested: ${input}`,
+        });
+      };
+
+      const parentPlugin: Plugin = (srv) => {
+        srv.tool('parent-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => `parent: ${input}`,
+        });
+        srv.register(nestedPlugin);
+      };
+
+      const server = createMcpServer().register(parentPlugin).build();
+
+      expect(server.registry.hasTool('parent-tool')).toBe(true);
+      expect(server.registry.hasTool('nested-tool')).toBe(true);
+    });
+  });
+
+  describe('Plugin Error Handling', () => {
+    it('should handle plugin errors gracefully', () => {
+      const errorPlugin: Plugin = () => {
+        throw new Error('Plugin execution failed');
+      };
+
+      expect(() => {
+        createMcpServer().register(errorPlugin).build();
+      }).toThrow('Plugin execution failed');
+    });
+
+    it('should continue execution if one plugin fails', () => {
+      const errorPlugin: Plugin = () => {
+        throw new Error('Plugin failed');
+      };
+
+      const successPlugin: Plugin = (srv) => {
+        srv.tool('success-tool', {
+          input: schema(z.string()),
+          output: schema(z.string()),
+          handler: async (input) => input,
+        });
+      };
+
+      expect(() => {
+        createMcpServer().register(successPlugin).register(errorPlugin).build();
+      }).toThrow('Plugin failed');
+    });
+  });
+});

--- a/packages/server/src/internal/compose.ts
+++ b/packages/server/src/internal/compose.ts
@@ -1,0 +1,26 @@
+import type { InvokeFn, Middleware } from '../middleware/types';
+
+/**
+ * Composes an array of middleware functions into a single invoke function using the onion-model pattern.
+ *
+ * The composition works right-to-left: the last middleware in the array wraps the core function,
+ * and the first middleware becomes the outermost layer. This creates an "onion" where each
+ * middleware can execute code before and after calling the next layer.
+ *
+ * Example execution flow with middlewares [A, B, C]:
+ * 1. A (before) -> B (before) -> C (before) -> core -> C (after) -> B (after) -> A (after)
+ *
+ * @param middlewares - Array of middleware functions to compose
+ * @param coreInvokeFn - The core function that performs the actual operation
+ * @returns A composed function that applies all middleware in the correct order
+ */
+export function composeMiddlewares(middlewares: Middleware[], coreInvokeFn: InvokeFn): InvokeFn {
+  if (middlewares.length === 0) {
+    return coreInvokeFn;
+  }
+
+  return middlewares.reduceRight(
+    (next: InvokeFn, middleware: Middleware) => middleware(next),
+    coreInvokeFn,
+  );
+}

--- a/packages/server/src/middleware/builtin-error-wrapper.ts
+++ b/packages/server/src/middleware/builtin-error-wrapper.ts
@@ -1,0 +1,26 @@
+import type { CallResult, Middleware } from './types';
+
+/**
+ * Built-in error wrapper middleware that automatically converts thrown exceptions
+ * into error result objects. This middleware ensures that all errors are handled
+ * consistently across the middleware pipeline.
+ *
+ * On successful execution: returns the result unchanged
+ * On error: catches any thrown exception and returns { isError: true, content: error }
+ *
+ * Note: This middleware will be automatically registered during builder.build() in future steps.
+ */
+export const errorWrapperMiddleware: Middleware = (next) => {
+  return async (ctx) => {
+    try {
+      const result = await next(ctx);
+      return result;
+    } catch (error) {
+      const errorResult: CallResult = {
+        isError: true,
+        content: error,
+      };
+      return errorResult;
+    }
+  };
+};

--- a/packages/server/src/middleware/types.ts
+++ b/packages/server/src/middleware/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Context object passed to middleware and execution handlers.
+ * Contains information about the current operation being executed.
+ */
+export interface CallCtx {
+  type: 'tool' | 'prompt' | 'resource';
+  name: string;
+  input: unknown;
+  meta: {
+    start: bigint;
+  };
+}
+
+/**
+ * Result object returned from middleware and execution handlers.
+ * Note: This should be re-exported from @mcpkit/core in future iterations.
+ */
+export interface CallResult {
+  content: unknown;
+  isError?: boolean;
+}
+
+/**
+ * Function signature for invoking the next layer in the middleware chain.
+ */
+export type InvokeFn = (ctx: CallCtx) => Promise<CallResult>;
+
+/**
+ * Middleware function signature following the onion-model pattern.
+ * Takes the next function in the chain and returns a new function.
+ */
+export type Middleware = (next: InvokeFn) => InvokeFn;

--- a/packages/server/src/plugin/index.ts
+++ b/packages/server/src/plugin/index.ts
@@ -1,0 +1,10 @@
+import type { McpServerBuilder } from '../index';
+
+/**
+ * Complete plugin contract for extending MCP server functionality.
+ * Plugins can modify the server builder by adding tools, prompts, resources, or middleware.
+ *
+ * This is the complete plugin contract with no additional responsibilities.
+ * Future lifecycle hooks (onInit, onClose) are explicitly out-of-scope for this implementation.
+ */
+export type Plugin<T = unknown> = (srv: McpServerBuilder, opts?: T) => void;


### PR DESCRIPTION
- Implemented `errorWrapperMiddleware` to handle errors consistently across middleware.
- Created tests for error handling in middleware, ensuring proper error result structure.
- Added tests for middleware types, including `CallCtx`, `CallResult`, and `InvokeFn`.
- Developed a plugin system with tests for plugin registration, execution, and error handling.
- Enhanced server functionality with middleware integration and improved invoke function.
- Established a composition utility for middleware to streamline execution flow.
- Re-exported middleware and plugin types for better usability in external modules.